### PR TITLE
Fix default folder being "music"

### DIFF
--- a/src/gui/menus/PlayerMenu.cpp
+++ b/src/gui/menus/PlayerMenu.cpp
@@ -122,7 +122,6 @@ void drawBrowserPlayer(playbackInfo_t* info)
 
 PlayerMenu::PlayerMenu() {
 	expInst = std::make_unique<Explorer>("sdmc:/");
-	expInst->ChangeDir("music");
 }
 
 PlayerMenu::~PlayerMenu()


### PR DESCRIPTION
Having the default folder "music" causes undefined behaviour for people not having any "music" folder in the root of their SD card. Clicking the UI would cause trying to access random folders, for instance `sdmc:/music/3ds/3ds/3ds`