### PR TITLE
playlist-first playback flow + autoqueue files in directory

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -58,16 +58,16 @@ void parse_entries(json_t* entries_elem, settings_t* todo_config) {
 							json_array_foreach(value, index, value_arr) {
 								if (json_is_string(value_arr)) {
 									std::string tmp_filepath(json_string_value(value_arr));
-									tmp_playlist.filepath.push_back(tmp_filepath);
+									tmp_playlist.files.push_back(tmp_filepath);
 								}
 							}
 						} else if (json_is_string(value)) {
 							std::string tmp_filepath(json_string_value(value));
-							tmp_playlist.filepath.push_back(tmp_filepath);
+							tmp_playlist.files.push_back(tmp_filepath);
 						}
 					}
 				}
-				todo_config->playlist.push_back(tmp_playlist);
+				todo_config->playlists.push_back(tmp_playlist);
 			}
 			else
 			{
@@ -202,20 +202,20 @@ int Cfg::WriteJson(const char* outpath, settings_t* settings) {
 	json_object_set_new(set_obj, SETTING_LANGUAGE, json_string(i18n::Int2Code(settings->language).c_str()));
 	json_object_set_new(root, CONFIG_STRING, set_obj);
 
-	for (uint32_t i = 0; settings->playlist.size() > i; i++) {
+	for (uint32_t i = 0; settings->playlists.size() > i; i++) {
 		json_t *pls_obj = json_object();
-		json_object_set_new(pls_obj, PLAYLIST_NAME, json_string(settings->playlist[i].name.c_str()));
+		json_object_set_new(pls_obj, PLAYLIST_NAME, json_string(settings->playlists[i].name.c_str()));
 
-		if (settings->playlist[i].filepath.size() > 1) {
+		if (settings->playlists[i].files.size() > 1) {
 			json_t *pls_obj_arr = json_array();
 
-			for (uint32_t j = 0; settings->playlist[i].filepath.size() > j; j++)
-				json_array_append_new(pls_obj_arr, json_string(settings->playlist[i].filepath[j].c_str()));
+			for (uint32_t j = 0; settings->playlists[i].files.size() > j; j++)
+				json_array_append_new(pls_obj_arr, json_string(settings->playlists[i].files[j].c_str()));
 
 			json_object_set_new(pls_obj, PLAYLIST_FILE, pls_obj_arr);
 
-		} else if (settings->playlist[i].filepath.size() == 1)
-			json_object_set_new(pls_obj, PLAYLIST_FILE, json_string(settings->playlist[i].filepath[0].c_str()));
+		} else if (settings->playlists[i].files.size() == 1)
+			json_object_set_new(pls_obj, PLAYLIST_FILE, json_string(settings->playlists[i].files[0].c_str()));
 
 		json_array_append_new(pls_json_arr, pls_obj);
 	}
@@ -229,5 +229,5 @@ int Cfg::WriteJson(const char* outpath, settings_t* settings) {
 void Cfg::CleanSettings(settings_t* parsed_config)
 {
 	parsed_config->wildMidiConfig.clear();
-	parsed_config->playlist.clear();
+	parsed_config->playlists.clear();
 }

--- a/src/gui/menus/PlayerMenu.hpp
+++ b/src/gui/menus/PlayerMenu.hpp
@@ -16,6 +16,7 @@ class PlayerMenu : public Menu
 		void drawTop() const override;
 		void drawBottom() const override;
 		void update(touchPosition* touch) override;
+		int changeFile(const std::string &filepath, playbackInfo_t* playbackInfo);
 		void fblist(int rows, int startpoint, float size) const;
 	private:
 		void BrowserControls(touchPosition* touch);

--- a/src/parsecfg/m3uparse.cpp
+++ b/src/parsecfg/m3uparse.cpp
@@ -24,7 +24,7 @@ int M3u::Parse(const std::string& file, playlist_t* playlist) {
 			std::printf("Ignored.\n");
 		else {
 			std::string tmpfp(line);
-			playlist->filepath.push_back(tmpfp);
+			playlist->files.push_back(tmpfp);
 		}
 		
 	}

--- a/src/parsecfg/plsparse.cpp
+++ b/src/parsecfg/plsparse.cpp
@@ -11,7 +11,7 @@ int Pls::Parse(const std::string& file, playlist_t* playlist) {
 	int entries = 0;
 	INIReader plsFile(file);
 
-	playlist->filepath.clear();
+	playlist->files.clear();
 
 	if (plsFile.ParseError() != 0) {
 		return 1;
@@ -25,7 +25,7 @@ int Pls::Parse(const std::string& file, playlist_t* playlist) {
 			std::string tmpfp;
 			tmpfp = plsFile.Get("playlist", "File"+std::to_string(i), "");
 			if (tmpfp.size()) {
-				playlist->filepath.push_back(tmpfp);
+				playlist->files.push_back(tmpfp);
 			}
 		}
 		return 0;

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -23,13 +23,11 @@ typedef struct
 
 typedef struct
 {
-	std::string	filepath;
 	std::string	filename;
 	metaInfo_t	fileMeta;
 	settings_t	settings;
-	playlist_t	playlistfile;
-	int		usePlaylist; // 0 do not use playlist, 1 use playlistfile, 2 use playlist from settings
-	uint32_t	selectPlaylistOffset;
+	playlist_t	playlist;
+	size_t		playindex;
 } playbackInfo_t;
 
 enum Format {

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -1,11 +1,12 @@
 #ifndef __LIME_SETTINGS_H__
 #define __LIME_SETTINGS_H__
 #include <vector>
+#include <string>
 
 typedef struct
 {
 	std::string		 name;
-	std::vector<std::string> filepath;
+	std::vector<std::string> files;
 } playlist_t;
 
 typedef std::vector<playlist_t> playvec;
@@ -15,7 +16,7 @@ typedef struct
 	std::string		wildMidiConfig;
 	uint32_t		theme;
 	int			language;
-	playvec			playlist;
+	playvec		playlists;
 } settings_t;
 
 #endif


### PR DESCRIPTION
- playbackInfo is now playlist-centric, `filepath` field is replaced by an index into the playlist. inspired by VLC's behavior
- when changing file, slurp up all possibly-compatible files via extension (will change this to use GetFileType later)
- "playlist file" code to be tentatively removed (m3u files do the same stuff, right?)

fixes #22 